### PR TITLE
Fix ignored doctest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "libs/naxos"]
 	path = libs/naxos
 	url = https://github.com/pothitos/naxos.git
+[submodule "libs/libqasm/qasm_flex_bison/test/doctest"]
+	path = libs/libqasm/qasm_flex_bison/test/doctest
+	url = https://github.com/onqtam/doctest.git


### PR DESCRIPTION
FYI: this is what caused `bison/test/testqc.cpp:7:10: fatal error: doctest/doctest.h: No such file or directory` for Nikiforos.